### PR TITLE
change references of rehl to rhel

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 1. Run `yarn build:ubuntu` to test kibana on regular ubuntu linux
 1. Run `yarn build:oracle` to test kibana on oracle
 1. Run `yarn build:rhel` to test kibana on Red Hat Linux
-1. When all services have started, get into an interactive session in Kibana with either `yarn shell:ubuntu` or `yarn shell:oracle` or `yarn shell:rehl` depending on the variant that was just built
+1. When all services have started, get into an interactive session in Kibana with either `yarn shell:ubuntu` or `yarn shell:oracle` or `yarn shell:rhel` depending on the variant that was just built
 1. In the session, type `cd kibana-dev` then `tar xzf kibana-<version>-SNAPSHOT-linux-aarch64.tar.gz`
 1. Set the configuration with `cp kibana.yml kibana-<version>-SNAPSHOT/config/kibana.yml`
 1. Type `cd kibana-<version>-SNAPSHOT` then `bin/kibana` and watch the magic happen.

--- a/docker-compose.rhel.yml
+++ b/docker-compose.rhel.yml
@@ -4,4 +4,4 @@
 services:
   kibana:
     build:
-      dockerfile: ../vm/rehl/Dockerfile
+      dockerfile: ../vm/rhel/Dockerfile

--- a/package.json
+++ b/package.json
@@ -8,15 +8,15 @@
   "scripts": {
     "ubuntu": "docker compose --project-name kibana-dev-ubuntu",
     "oracle": "docker compose -f docker-compose.yml -f docker-compose.oracle-linux.yml --project-name kibana-dev-oracle",
-    "rehl": "docker compose -f docker-compose.yml -f docker-compose.rhel.yml --project-name kibana-dev-rhel",
+    "rhel": "docker compose -f docker-compose.yml -f docker-compose.rhel.yml --project-name kibana-dev-rhel",
     "build:ubuntu": "yarn ubuntu up -d --build",
     "build:oracle": "yarn oracle up -d --build",
-    "build:rehl": "yarn rhel up -d --build",
+    "build:rhel": "yarn rhel up -d --build",
     "shell:ubuntu": "yarn ubuntu exec kibana /bin/bash",
     "shell:oracle": "yarn oracle exec kibana /bin/bash",
-    "shell:rehl": "yarn rehl exec kibana /bin/bash",
+    "shell:rhel": "yarn rhel exec kibana /bin/bash",
     "terminate:ubuntu": "yarn ubuntu down",
     "terminate:oracle": "yarn oracle down",
-    "terminate:rehl": "yarn rehl down"
+    "terminate:rhel": "yarn rhel down"
   }
 }


### PR DESCRIPTION
Tested the RHEL version of this today, there are a bunch of typos of `rehl` where it should be `rhel`